### PR TITLE
Remove manual cache update

### DIFF
--- a/uebungen/06-more-roles/roles/postgresql/tasks/main.yml
+++ b/uebungen/06-more-roles/roles/postgresql/tasks/main.yml
@@ -17,7 +17,6 @@
   apt_repository:
     repo: "deb {{ postgresql_repository_apt }} {{ lsb_release.stdout }}-pgdg main"
     state: present
-    update_cache: yes
     # the "filename" requires Ansible 2.1 or later
     filename: postgresql-repository
 

--- a/uebungen/06-more-roles/roles/postgresql/tasks/main.yml
+++ b/uebungen/06-more-roles/roles/postgresql/tasks/main.yml
@@ -21,10 +21,6 @@
     filename: postgresql-repository
 
 
-- name: Update apt cache
-  apt: update_cache=yes
-
-
 - name: Install PostgreSQL packages
   package:
     name: "{{ item }}"


### PR DESCRIPTION
* Remove `update_cache: yes` - this is the default option for the apt_repository module and can be omitted.
* Remove manual `apt-get update` call - this is not necessary because the update has already been executed by `apt_repository`.